### PR TITLE
AdminAPI suggestions

### DIFF
--- a/src/sdk/AdminAPI.js
+++ b/src/sdk/AdminAPI.js
@@ -46,6 +46,14 @@ define([
         return this._disposables.dispose();
     };
 
+    AdminAPI.prototype.getAuthenticationData = function getAuthenticationData() {
+        return this._authenticationData;
+    };
+
+    AdminAPI.prototype.setAuthenticationData = function setAuthenticationData(authenticationData) {
+        this._authenticationData = authenticationData;
+    };
+
     AdminAPI.prototype.createAuthenticationToken = function createAuthenticationToken(callback) {
         var data = appendAuthDataTo.call(this, {});
         var requestWithoutCallback = _.bind(http.postWithRetry, http, this._backendUri + '/auth', JSON.stringify(data), defaultRequestOptions);

--- a/src/sdk/express/PCastExpress.js
+++ b/src/sdk/express/PCastExpress.js
@@ -101,6 +101,14 @@ define([
         this._reauthCount = 0;
     };
 
+    PCastExpress.prototype.getAuthToken = function getAuthToken() {
+        return this._authToken;
+    };
+
+    PCastExpress.prototype.setAuthToken = function setAuthToken(authToken) {
+        this._authToken = authToken;
+    };
+
     PCastExpress.prototype.getPCast = function getPCast() {
         return this._pcastObservable.getValue();
     };

--- a/src/sdk/express/PCastExpress.js
+++ b/src/sdk/express/PCastExpress.js
@@ -37,8 +37,13 @@ define([
 
     function PCastExpress(options) {
         assert.isObject(options, 'options');
-        assert.isStringNotEmpty(options.backendUri, 'options.backendUri');
-        assert.isObject(options.authenticationData, 'options.authenticationData');
+
+        if (options.adminApi) {
+            assert.isObject(options.adminApi, 'options.adminApi');
+        } else {
+            assert.isStringNotEmpty(options.backendUri, 'options.backendUri');
+            assert.isObject(options.authenticationData, 'options.authenticationData');
+        }
 
         if (options.authToken) {
             assert.isStringNotEmpty(options.authToken, 'options.authToken');
@@ -65,7 +70,7 @@ define([
         this._pcastObservable = new observable.Observable(null).extend({rateLimit: 0});
         this._subscribers = {};
         this._publishers = {};
-        this._adminAPI = new AdminAPI(options.backendUri, options.authenticationData);
+        this._adminAPI = options.adminApi || new AdminAPI(options.backendUri, options.authenticationData);
         this._isInstantiated = false;
         this._reauthCount = 0;
         this._reconnectCount = 0;

--- a/src/sdk/express/RoomExpress.js
+++ b/src/sdk/express/RoomExpress.js
@@ -38,9 +38,6 @@ define([
 
         if (options.pcastExpress) {
             assert.isObject(options.pcastExpress, 'options.pcastExpress');
-        } else {
-            assert.isStringNotEmpty(options.backendUri, 'options.backendUri');
-            assert.isObject(options.authenticationData, 'options.authenticationData');
         }
 
         this._pcastExpress = options.pcastExpress || new PCastExpress(options);

--- a/src/web-sdk.js
+++ b/src/web-sdk.js
@@ -19,6 +19,7 @@ define('phenix-web-sdk', [
     'phenix-rtc',
     'phenix-web-logging',
     './sdk/PCast',
+    './sdk/AdminAPI',
     './sdk/room/RoomService',
     './sdk/audio/AudioSpeakerDetector',
     './sdk/bandwidth/BandwidthMonitor',
@@ -31,6 +32,7 @@ define('phenix-web-sdk', [
 
     return {
         PCast: PCast,
+        AdminAPI: AdminAPI,
         RoomService: RoomService,
         AudioSpeakerDetector: AudioSpeakerDetector,
         BandwidthMonitor: BandwidthMonitor,


### PR DESCRIPTION
- We currently push a rotating token to clients, but it can only be provided in the constructor as `options.authToken`, and there's no way to update it on an existing instance. A similar problem surrounds `authenticationData`.

   Things pretty much work right now, because our instances are created directly before opening the stream, using the most recent token, which should be valid for ~1 hour per the docs. Just not sure how fragile this is, in case PCastExpress needs to get back to the admin API beyond that lifespan or for some other reason.

- Ideally, we'd like to have a custom AdminAPI, so that we can send XHR requests with `withCredentials = true`, reusing our cookie-based sessions. We're also integrating with a native wrapper, which could then implement an AdminAPI that delegates to JS in a webview.

   I understand that similar changes would have to be made to the native SDKs, and that'd be a bit more involved. Especially considering AdminAPI may need an extra protocol/interface layer in a typed language. (Stuff like `backendUri`/`authenticationData` is probably specific to the default impl in that case.)

Feel free to do with these changes as you like. It's just a rough draft, and be warned, I never tested this code. :)